### PR TITLE
moved the version for overriding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "curve25519-dalek"
 # - update html_root_url
 # - update README if required by semver
 # - if README was updated, also update module documentation in src/lib.rs
-version = "4.0.0-pre.2"
+version = "3.2.0"
 authors = ["Isis Lovecruft <isis@patternsinthevoid.net>",
            "Henry de Valence <hdevalence@hdevalence.ca>"]
 readme = "README.md"


### PR DESCRIPTION
### Description

The `Cargo.toml` file has been modified in this PR to change the version of the "curve25519-dalek" dependency.

- Update the version of the "curve25519-dalek" dependency from "4.0.0-pre.2" to "3.2.0".
- Authors' details remain the same.

These changes revert the version of the "curve25519-dalek" dependency to "3.2.0".